### PR TITLE
feat(auth): change behavior on subsequent init calls

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -24,14 +24,15 @@ export namespace Diggithy {
                 Auth.instance = new Auth();
             }
 
-            if (apiKey) {
-                Auth.instance.apiKey = apiKey;
-            } else {
-                Auth.instance.apiKey = process.env.DIGGITHY_API_KEY;
+            const newApiKey = apiKey ?? process.env.DIGGITHY_API_KEY;
+
+            if (!newApiKey) {
+                console.warn(warnings.noApiKeyConfigured);
             }
 
-            if (!Auth.instance.apiKey) {
-                console.warn(warnings.noApiKeyConfigured);
+            if (newApiKey !== Auth.instance.apiKey) {
+                Auth.instance.apiKey = newApiKey;
+                Auth.instance.token = undefined;
             }
         }
 

--- a/test/unit/auth.spec.ts
+++ b/test/unit/auth.spec.ts
@@ -41,6 +41,28 @@ describe(Diggithy.Auth.name, () => {
 
                 expect(consoleSpy).toBeCalledWith(warnings.noApiKeyConfigured);
             });
+
+            it("should delete token on subsequent calls with a different API key", () => {
+                Diggithy.Auth.init();
+
+                const instance = Reflect.get(Diggithy.Auth, "instance");
+                Reflect.set(instance, "token", "someToken");
+
+                Diggithy.Auth.init("someDifferentApiKey");
+
+                expect(Reflect.get(instance, "token")).toBeUndefined();
+            });
+
+            it("should keep token on subsequent calls with equal API key", () => {
+                Diggithy.Auth.init();
+
+                const instance = Reflect.get(Diggithy.Auth, "instance");
+                Reflect.set(instance, "token", "someToken");
+
+                Diggithy.Auth.init();
+
+                expect(Reflect.get(instance, "token")).toBe("someToken");
+            });
         });
 
         describe("getToken", () => {


### PR DESCRIPTION
## Description

On subsequent `Diggithy.Auth.iinit()` calls with the same API key as the one that was already set, nothing should
happen. On the other hand, an existing token should be deleted if a new key is used.

## Related Issues

n/a

## Types of changes
-   [ ] 🦠 Bug fix (change which fixes an issue)
-   [ ] 🎉 New feature (change which adds functionality)
-   [x] 👌 Improvement (change which improves existing functionality)
-   [ ] ⚙️ Configuration (change which changes framework or runtime behavior)
-   [ ] 📝 Documentation
-   [ ] ⚠️ Breaking change (any of the above that breaks existing functionality or compatibility with other components)

## Checklist
-   [x] I chose at least one reviewer on the right side (choose `loud-gmbh/diggithy` if you are not sure who to pick).
-   [x] I have added unit and e2e tests to cover my changes.
-   [x] All new and existing tests passed locally.
-   [ ] I have updated the documentation accordingly.
